### PR TITLE
Resolve issue with expose.py environment variable

### DIFF
--- a/endgame/command/expose.py
+++ b/endgame/command/expose.py
@@ -67,7 +67,7 @@ CBLINK2 = '\33[6m'
     required=False,
     default="us-east-1",
     help="The AWS region",
-    envvar="AWS_SERVICE"
+    envvar="AWS_REGION"
 )
 @click.option(
     "--dry-run",


### PR DESCRIPTION
## What does this PR do?
This PR resolves #58 by changing the envvar assigned to `--region` in `endgame/command/expose.py` to be `AWS_REGION` instead of `AWS_SERVICE`.

## What gif best describes this PR or how it makes you feel?
![image](https://user-images.githubusercontent.com/53876939/108018049-3786c700-6fdc-11eb-815f-12114aff21c4.png)
(I, too, was shocked to get Google results for "environment variable meme")

## Completion checklist

- [ ] Additions and changes have unit tests
- [ ] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/endgame/actions). GitHub actions does this automatically
- [ ] The pull request has been appropriately labeled using the provided PR labels
